### PR TITLE
New Lineages Update: 13 new lineages active through 2022-12-01

### DIFF
--- a/lineage_notes.txt
+++ b/lineage_notes.txt
@@ -2586,3 +2586,16 @@ XBJ	Recombinant lineage of BA.2.3.20 and BA.5.2, possibly Philippines, from pang
 *H.1	Withdrawn: Alias of B.1.1.67.1, South African lineage, split from B.1.1.10
 *I.1	Withdrawn: Alias of B.1.1.217.1, Latvian lineage, split from B.1.1.25
 *J.1	Withdrawn: Alias of B.1.1.250.1, Australian lineage
+auto.XBB.1.4.0	Alias of auto.XBB.1.4.0, defined by S:S673G, found in Denmark, Norway, and Sweden. Automatically inferred by https://github.com/jmcbroome/automate-lineages-prototype.
+auto.BN.1.3.	Alias of auto.BN.1.3, defined by ORF1ab:F3753L, ORF1ab:H4831Y, found in Denmark. Automatically inferred by https://github.com/jmcbroome/automate-lineages-prototype.
+auto.BQ.1.2.3	Alias of auto.BQ.1.2.3, defined by N:H300N, ORF1ab:P5828S, found in Mongolia, Turkey, and USA. Automatically inferred by https://github.com/jmcbroome/automate-lineages-prototype.
+auto.BQ.1.13.2	Alias of auto.BQ.1.13.2, defined by S:F157L, found in USA, Netherlands, and England. Automatically inferred by https://github.com/jmcbroome/automate-lineages-prototype.
+auto.BQ.1.23.2	Alias of auto.BQ.1.23.2, defined by ORF1ab:D1939G, found in Australia. Automatically inferred by https://github.com/jmcbroome/automate-lineages-prototype.
+auto.BQ.1.1.4.3	Alias of auto.BQ.1.1.4.3, defined by ORF1ab:T1168A, found in Denmark, Croatia, and Australia. Automatically inferred by https://github.com/jmcbroome/automate-lineages-prototype.
+auto.BQ.1.1.20.1	Alias of auto.BQ.1.1.20.1, defined by S:A1070V, found in Denmark. Automatically inferred by https://github.com/jmcbroome/automate-lineages-prototype.
+auto.BN.1.3.	Alias of auto.BN.1.3, defined by ORF1ab:F3753L, ORF1ab:H4831Y, found in Denmark and USA. Automatically inferred by https://github.com/jmcbroome/automate-lineages-prototype.
+auto.BQ.1.2.3	Alias of auto.BQ.1.2.3, defined by N:H300N, ORF1ab:P5828S, found in Mongolia, Turkey, and Japan. Automatically inferred by https://github.com/jmcbroome/automate-lineages-prototype.
+auto.BQ.1.13.2	Alias of auto.BQ.1.13.2, defined by S:F157L, found in USA, Israel, and Netherlands. Automatically inferred by https://github.com/jmcbroome/automate-lineages-prototype.
+auto.BQ.1.23.2	Alias of auto.BQ.1.23.2, defined by ORF1ab:T3488I, found in Indonesia, Singapore, and USA. Automatically inferred by https://github.com/jmcbroome/automate-lineages-prototype.
+auto.BQ.1.1.4.3	Alias of auto.BQ.1.1.4.3, defined by ORF7a:I100F, found in USA, Colombia, and Guatemala. Automatically inferred by https://github.com/jmcbroome/automate-lineages-prototype.
+auto.BQ.1.1.20.1	Alias of auto.BQ.1.1.20.1, defined by S:A1070V, found in Denmark. Automatically inferred by https://github.com/jmcbroome/automate-lineages-prototype.


### PR DESCRIPTION
| proposed_sublineage   | parent    |   proposed_sublineage_size | earliest_child   | final_date   |   size | child_regions                                                                                                    | aa_changes                   | link                                                                                                                                                                                                    | taxlink                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
|:----------------------|:----------|---------------------------:|:-----------------|:-------------|-------:|:-----------------------------------------------------------------------------------------------------------------|:-----------------------------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| auto.XBB.1.4.0        | XBB.1.4   |                         32 | 2022-10-10       | 2022-12-01   |    115 | Denmark,Norway,Sweden,Austria,Iceland,Israel                                                                     | >S:S673G                     | [View On Cov-Spectrum](https://cov-spectrum.org/explore/World/AllSamples/AllTimes/variants?variantQuery=nextcladePangoLineage%3AXBB.1.4%2A%26%5B3-of%3A26160C%2C+2164A%2C+23579G%5D)                    | [View On Taxonium (Public Samples Only)](https://taxonium.org/?backend=https://api.cov2tree.org&srch=%5B%7B%22key%22%3A%22aa1%22%2C%22type%22%3A%22boolean%22%2C%22method%22%3A%22boolean%22%2C%22text%22%3A%22XBB.1.4%22%2C%22gene%22%3A%22S%22%2C%22position%22%3A484%2C%22new_residue%22%3A%22any%22%2C%22min_tips%22%3A0%2C%22subspecs%22%3A%5B%7B%22key%22%3A%22ab0%22%2C%22type%22%3A%22meta_pango_lineage_usher%22%2C%22method%22%3A%22text_exact%22%2C%22text%22%3A%22XBB.1.4%22%2C%22gene%22%3A%22S%22%2C%22position%22%3A484%2C%22new_residue%22%3A%22any%22%2C%22min_tips%22%3A0%7D%2C%7B%22key%22%3A%221ab%22%2C%22type%22%3A%22genotype%22%2C%22method%22%3A%22genotype%22%2C%22text%22%3A%22%22%2C%22gene%22%3A%22nt%22%2C%22position%22%3A%2226160%22%2C%22new_residue%22%3A%22C%22%2C%22min_tips%22%3A0%7D%2C%7B%22key%22%3A%222ab%22%2C%22type%22%3A%22genotype%22%2C%22method%22%3A%22genotype%22%2C%22text%22%3A%22%22%2C%22gene%22%3A%22nt%22%2C%22position%22%3A%222164%22%2C%22new_residue%22%3A%22A%22%2C%22min_tips%22%3A0%7D%2C%7B%22key%22%3A%223ab%22%2C%22type%22%3A%22genotype%22%2C%22method%22%3A%22genotype%22%2C%22text%22%3A%22%22%2C%22gene%22%3A%22nt%22%2C%22position%22%3A%2223579%22%2C%22new_residue%22%3A%22G%22%2C%22min_tips%22%3A0%7D%5D%2C%22boolean_method%22%3A%22and%22%7D%5D&enabled=%7B%22aa1%22%3A%22true%22%7D&zoomToSearch=0)                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
| auto.BN.1.3           | BN.1      |                         39 | 2022-10-11       | 2022-12-01   |     75 | Denmark,Canada,Austria,USA                                                                                       | ORF1ab:F3753L,ORF1ab:H4831Y> | [View On Cov-Spectrum](https://cov-spectrum.org/explore/World/AllSamples/AllTimes/variants?variantQuery=nextcladePangoLineage%3ABN.1%2A%26%5B3-of%3A19839C%2C+14755T%2C+11522C%5D)                      | [View On Taxonium (Public Samples Only)](https://taxonium.org/?backend=https://api.cov2tree.org&srch=%5B%7B%22key%22%3A%22aa1%22%2C%22type%22%3A%22boolean%22%2C%22method%22%3A%22boolean%22%2C%22text%22%3A%22BN.1%22%2C%22gene%22%3A%22S%22%2C%22position%22%3A484%2C%22new_residue%22%3A%22any%22%2C%22min_tips%22%3A0%2C%22subspecs%22%3A%5B%7B%22key%22%3A%22ab0%22%2C%22type%22%3A%22meta_pango_lineage_usher%22%2C%22method%22%3A%22text_exact%22%2C%22text%22%3A%22BN.1%22%2C%22gene%22%3A%22S%22%2C%22position%22%3A484%2C%22new_residue%22%3A%22any%22%2C%22min_tips%22%3A0%7D%2C%7B%22key%22%3A%221ab%22%2C%22type%22%3A%22genotype%22%2C%22method%22%3A%22genotype%22%2C%22text%22%3A%22%22%2C%22gene%22%3A%22nt%22%2C%22position%22%3A%2211522%22%2C%22new_residue%22%3A%22C%22%2C%22min_tips%22%3A0%7D%2C%7B%22key%22%3A%222ab%22%2C%22type%22%3A%22genotype%22%2C%22method%22%3A%22genotype%22%2C%22text%22%3A%22%22%2C%22gene%22%3A%22nt%22%2C%22position%22%3A%2214755%22%2C%22new_residue%22%3A%22T%22%2C%22min_tips%22%3A0%7D%2C%7B%22key%22%3A%223ab%22%2C%22type%22%3A%22genotype%22%2C%22method%22%3A%22genotype%22%2C%22text%22%3A%22%22%2C%22gene%22%3A%22nt%22%2C%22position%22%3A%2219839%22%2C%22new_residue%22%3A%22C%22%2C%22min_tips%22%3A0%7D%5D%2C%22boolean_method%22%3A%22and%22%7D%5D&enabled=%7B%22aa1%22%3A%22true%22%7D&zoomToSearch=0)                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
| auto.BQ.1.2.3         | BQ.1.2    |                         45 | 2022-09-07       | 2022-12-01   |     78 | Mongolia,Turkey,USA,Japan,Israel,Netherlands,SouthKorea,England,Denmark,Germany,Spain                            | N:H300N>ORF1ab:P5828S>       | [View On Cov-Spectrum](https://cov-spectrum.org/explore/World/AllSamples/AllTimes/variants?variantQuery=nextcladePangoLineage%3ABQ.1.2%2A%26%5B5-of%3A17746T%2C+4414G%2C+29171A%2C+27513T%2C+15960A%5D) | [View On Taxonium (Public Samples Only)](https://taxonium.org/?backend=https://api.cov2tree.org&srch=%5B%7B%22key%22%3A%22aa1%22%2C%22type%22%3A%22boolean%22%2C%22method%22%3A%22boolean%22%2C%22text%22%3A%22BQ.1.2%22%2C%22gene%22%3A%22S%22%2C%22position%22%3A484%2C%22new_residue%22%3A%22any%22%2C%22min_tips%22%3A0%2C%22subspecs%22%3A%5B%7B%22key%22%3A%22ab0%22%2C%22type%22%3A%22meta_pango_lineage_usher%22%2C%22method%22%3A%22text_exact%22%2C%22text%22%3A%22BQ.1.2%22%2C%22gene%22%3A%22S%22%2C%22position%22%3A484%2C%22new_residue%22%3A%22any%22%2C%22min_tips%22%3A0%7D%2C%7B%22key%22%3A%221ab%22%2C%22type%22%3A%22genotype%22%2C%22method%22%3A%22genotype%22%2C%22text%22%3A%22%22%2C%22gene%22%3A%22nt%22%2C%22position%22%3A%2215960%22%2C%22new_residue%22%3A%22A%22%2C%22min_tips%22%3A0%7D%2C%7B%22key%22%3A%222ab%22%2C%22type%22%3A%22genotype%22%2C%22method%22%3A%22genotype%22%2C%22text%22%3A%22%22%2C%22gene%22%3A%22nt%22%2C%22position%22%3A%2227513%22%2C%22new_residue%22%3A%22T%22%2C%22min_tips%22%3A0%7D%2C%7B%22key%22%3A%223ab%22%2C%22type%22%3A%22genotype%22%2C%22method%22%3A%22genotype%22%2C%22text%22%3A%22%22%2C%22gene%22%3A%22nt%22%2C%22position%22%3A%2229171%22%2C%22new_residue%22%3A%22A%22%2C%22min_tips%22%3A0%7D%2C%7B%22key%22%3A%224ab%22%2C%22type%22%3A%22genotype%22%2C%22method%22%3A%22genotype%22%2C%22text%22%3A%22%22%2C%22gene%22%3A%22nt%22%2C%22position%22%3A%2217746%22%2C%22new_residue%22%3A%22T%22%2C%22min_tips%22%3A0%7D%2C%7B%22key%22%3A%225ab%22%2C%22type%22%3A%22genotype%22%2C%22method%22%3A%22genotype%22%2C%22text%22%3A%22%22%2C%22gene%22%3A%22nt%22%2C%22position%22%3A%224414%22%2C%22new_residue%22%3A%22G%22%2C%22min_tips%22%3A0%7D%5D%2C%22boolean_method%22%3A%22and%22%7D%5D&enabled=%7B%22aa1%22%3A%22true%22%7D&zoomToSearch=0) |
| auto.BQ.1.13.2        | BQ.1.13   |                         38 | 2022-10-10       | 2022-12-01   |     68 | USA,Netherlands,England,Israel,Iceland,Australia,Canada                                                          | >S:F157L>                    | [View On Cov-Spectrum](https://cov-spectrum.org/explore/World/AllSamples/AllTimes/variants?variantQuery=nextcladePangoLineage%3ABQ.1.13%2A%26%5B4-of%3A7318T%2C+22033A%2C+19266C%2C+26106C%5D)          | [View On Taxonium (Public Samples Only)](https://taxonium.org/?backend=https://api.cov2tree.org&srch=%5B%7B%22key%22%3A%22aa1%22%2C%22type%22%3A%22boolean%22%2C%22method%22%3A%22boolean%22%2C%22text%22%3A%22BQ.1.13%22%2C%22gene%22%3A%22S%22%2C%22position%22%3A484%2C%22new_residue%22%3A%22any%22%2C%22min_tips%22%3A0%2C%22subspecs%22%3A%5B%7B%22key%22%3A%22ab0%22%2C%22type%22%3A%22meta_pango_lineage_usher%22%2C%22method%22%3A%22text_exact%22%2C%22text%22%3A%22BQ.1.13%22%2C%22gene%22%3A%22S%22%2C%22position%22%3A484%2C%22new_residue%22%3A%22any%22%2C%22min_tips%22%3A0%7D%2C%7B%22key%22%3A%221ab%22%2C%22type%22%3A%22genotype%22%2C%22method%22%3A%22genotype%22%2C%22text%22%3A%22%22%2C%22gene%22%3A%22nt%22%2C%22position%22%3A%227318%22%2C%22new_residue%22%3A%22T%22%2C%22min_tips%22%3A0%7D%2C%7B%22key%22%3A%222ab%22%2C%22type%22%3A%22genotype%22%2C%22method%22%3A%22genotype%22%2C%22text%22%3A%22%22%2C%22gene%22%3A%22nt%22%2C%22position%22%3A%2222033%22%2C%22new_residue%22%3A%22A%22%2C%22min_tips%22%3A0%7D%2C%7B%22key%22%3A%223ab%22%2C%22type%22%3A%22genotype%22%2C%22method%22%3A%22genotype%22%2C%22text%22%3A%22%22%2C%22gene%22%3A%22nt%22%2C%22position%22%3A%2219266%22%2C%22new_residue%22%3A%22C%22%2C%22min_tips%22%3A0%7D%2C%7B%22key%22%3A%224ab%22%2C%22type%22%3A%22genotype%22%2C%22method%22%3A%22genotype%22%2C%22text%22%3A%22%22%2C%22gene%22%3A%22nt%22%2C%22position%22%3A%2226106%22%2C%22new_residue%22%3A%22C%22%2C%22min_tips%22%3A0%7D%5D%2C%22boolean_method%22%3A%22and%22%7D%5D&enabled=%7B%22aa1%22%3A%22true%22%7D&zoomToSearch=0)                                                                                                                                                                                                                           |
| auto.BQ.1.23.2        | BQ.1.23   |                         28 | 2022-10-15       | 2022-12-01   |     43 | Australia,Singapore,USA                                                                                          | >>ORF1ab:D1939G              | [View On Cov-Spectrum](https://cov-spectrum.org/explore/World/AllSamples/AllTimes/variants?variantQuery=nextcladePangoLineage%3ABQ.1.23%2A%26%5B3-of%3A4144A%2C+6081G%2C+22591T%5D)                     | [View On Taxonium (Public Samples Only)](https://taxonium.org/?backend=https://api.cov2tree.org&srch=%5B%7B%22key%22%3A%22aa1%22%2C%22type%22%3A%22boolean%22%2C%22method%22%3A%22boolean%22%2C%22text%22%3A%22BQ.1.23%22%2C%22gene%22%3A%22S%22%2C%22position%22%3A484%2C%22new_residue%22%3A%22any%22%2C%22min_tips%22%3A0%2C%22subspecs%22%3A%5B%7B%22key%22%3A%22ab0%22%2C%22type%22%3A%22meta_pango_lineage_usher%22%2C%22method%22%3A%22text_exact%22%2C%22text%22%3A%22BQ.1.23%22%2C%22gene%22%3A%22S%22%2C%22position%22%3A484%2C%22new_residue%22%3A%22any%22%2C%22min_tips%22%3A0%7D%2C%7B%22key%22%3A%221ab%22%2C%22type%22%3A%22genotype%22%2C%22method%22%3A%22genotype%22%2C%22text%22%3A%22%22%2C%22gene%22%3A%22nt%22%2C%22position%22%3A%2222591%22%2C%22new_residue%22%3A%22T%22%2C%22min_tips%22%3A0%7D%2C%7B%22key%22%3A%222ab%22%2C%22type%22%3A%22genotype%22%2C%22method%22%3A%22genotype%22%2C%22text%22%3A%22%22%2C%22gene%22%3A%22nt%22%2C%22position%22%3A%224144%22%2C%22new_residue%22%3A%22A%22%2C%22min_tips%22%3A0%7D%2C%7B%22key%22%3A%223ab%22%2C%22type%22%3A%22genotype%22%2C%22method%22%3A%22genotype%22%2C%22text%22%3A%22%22%2C%22gene%22%3A%22nt%22%2C%22position%22%3A%226081%22%2C%22new_residue%22%3A%22G%22%2C%22min_tips%22%3A0%7D%5D%2C%22boolean_method%22%3A%22and%22%7D%5D&enabled=%7B%22aa1%22%3A%22true%22%7D&zoomToSearch=0)                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
| auto.BQ.1.1.4.3       | BQ.1.1.4  |                         20 | 2022-10-18       | 2022-12-01   |     79 | Denmark,Croatia,Australia,Israel,USA,Sweden                                                                      | ORF1ab:T1168A>               | [View On Cov-Spectrum](https://cov-spectrum.org/explore/World/AllSamples/AllTimes/variants?variantQuery=nextcladePangoLineage%3ABQ.1.1.4%2A%26%5B2-of%3A28657T%2C+3767G%5D)                             | [View On Taxonium (Public Samples Only)](https://taxonium.org/?backend=https://api.cov2tree.org&srch=%5B%7B%22key%22%3A%22aa1%22%2C%22type%22%3A%22boolean%22%2C%22method%22%3A%22boolean%22%2C%22text%22%3A%22BQ.1.1.4%22%2C%22gene%22%3A%22S%22%2C%22position%22%3A484%2C%22new_residue%22%3A%22any%22%2C%22min_tips%22%3A0%2C%22subspecs%22%3A%5B%7B%22key%22%3A%22ab0%22%2C%22type%22%3A%22meta_pango_lineage_usher%22%2C%22method%22%3A%22text_exact%22%2C%22text%22%3A%22BQ.1.1.4%22%2C%22gene%22%3A%22S%22%2C%22position%22%3A484%2C%22new_residue%22%3A%22any%22%2C%22min_tips%22%3A0%7D%2C%7B%22key%22%3A%221ab%22%2C%22type%22%3A%22genotype%22%2C%22method%22%3A%22genotype%22%2C%22text%22%3A%22%22%2C%22gene%22%3A%22nt%22%2C%22position%22%3A%223767%22%2C%22new_residue%22%3A%22G%22%2C%22min_tips%22%3A0%7D%2C%7B%22key%22%3A%222ab%22%2C%22type%22%3A%22genotype%22%2C%22method%22%3A%22genotype%22%2C%22text%22%3A%22%22%2C%22gene%22%3A%22nt%22%2C%22position%22%3A%2228657%22%2C%22new_residue%22%3A%22T%22%2C%22min_tips%22%3A0%7D%5D%2C%22boolean_method%22%3A%22and%22%7D%5D&enabled=%7B%22aa1%22%3A%22true%22%7D&zoomToSearch=0)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
| auto.BQ.1.1.20.1      | BQ.1.1.20 |                         53 | 2022-10-24       | 2022-12-01   |     90 | Denmark                                                                                                          | S:A1070V                     | [View On Cov-Spectrum](https://cov-spectrum.org/explore/World/AllSamples/AllTimes/variants?variantQuery=nextcladePangoLineage%3ABQ.1.1.20%2A%26%5B1-of%3A24771T%5D)                                     | [View On Taxonium (Public Samples Only)](https://taxonium.org/?backend=https://api.cov2tree.org&srch=%5B%7B%22key%22%3A%22aa1%22%2C%22type%22%3A%22boolean%22%2C%22method%22%3A%22boolean%22%2C%22text%22%3A%22BQ.1.1.20%22%2C%22gene%22%3A%22S%22%2C%22position%22%3A484%2C%22new_residue%22%3A%22any%22%2C%22min_tips%22%3A0%2C%22subspecs%22%3A%5B%7B%22key%22%3A%22ab0%22%2C%22type%22%3A%22meta_pango_lineage_usher%22%2C%22method%22%3A%22text_exact%22%2C%22text%22%3A%22BQ.1.1.20%22%2C%22gene%22%3A%22S%22%2C%22position%22%3A484%2C%22new_residue%22%3A%22any%22%2C%22min_tips%22%3A0%7D%2C%7B%22key%22%3A%221ab%22%2C%22type%22%3A%22genotype%22%2C%22method%22%3A%22genotype%22%2C%22text%22%3A%22%22%2C%22gene%22%3A%22nt%22%2C%22position%22%3A%2224771%22%2C%22new_residue%22%3A%22T%22%2C%22min_tips%22%3A0%7D%5D%2C%22boolean_method%22%3A%22and%22%7D%5D&enabled=%7B%22aa1%22%3A%22true%22%7D&zoomToSearch=0)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
| auto.BN.1.3           | BN.1      |                         75 | 2022-09-16       | 2022-12-01   |     75 | Denmark,USA,Canada,Austria,Germany                                                                               | ORF1ab:F3753L>ORF1ab:H4831Y  | [View On Cov-Spectrum](https://cov-spectrum.org/explore/World/AllSamples/AllTimes/variants?variantQuery=nextcladePangoLineage%3ABN.1%2A%26%5B2-of%3A14755T%2C+11522C%5D)                                | [View On Taxonium (Public Samples Only)](https://taxonium.org/?backend=https://api.cov2tree.org&srch=%5B%7B%22key%22%3A%22aa1%22%2C%22type%22%3A%22boolean%22%2C%22method%22%3A%22boolean%22%2C%22text%22%3A%22BN.1%22%2C%22gene%22%3A%22S%22%2C%22position%22%3A484%2C%22new_residue%22%3A%22any%22%2C%22min_tips%22%3A0%2C%22subspecs%22%3A%5B%7B%22key%22%3A%22ab0%22%2C%22type%22%3A%22meta_pango_lineage_usher%22%2C%22method%22%3A%22text_exact%22%2C%22text%22%3A%22BN.1%22%2C%22gene%22%3A%22S%22%2C%22position%22%3A484%2C%22new_residue%22%3A%22any%22%2C%22min_tips%22%3A0%7D%2C%7B%22key%22%3A%221ab%22%2C%22type%22%3A%22genotype%22%2C%22method%22%3A%22genotype%22%2C%22text%22%3A%22%22%2C%22gene%22%3A%22nt%22%2C%22position%22%3A%2211522%22%2C%22new_residue%22%3A%22C%22%2C%22min_tips%22%3A0%7D%2C%7B%22key%22%3A%222ab%22%2C%22type%22%3A%22genotype%22%2C%22method%22%3A%22genotype%22%2C%22text%22%3A%22%22%2C%22gene%22%3A%22nt%22%2C%22position%22%3A%2214755%22%2C%22new_residue%22%3A%22T%22%2C%22min_tips%22%3A0%7D%5D%2C%22boolean_method%22%3A%22and%22%7D%5D&enabled=%7B%22aa1%22%3A%22true%22%7D&zoomToSearch=0)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
| auto.BQ.1.2.3         | BQ.1.2    |                         78 | 2022-09-07       | 2022-12-01   |     78 | Mongolia,Turkey,Japan,USA,Israel,Germany,Austria,Netherlands,SouthKorea,England,Denmark,Spain,Australia          | N:H300N>ORF1ab:P5828S>       | [View On Cov-Spectrum](https://cov-spectrum.org/explore/World/AllSamples/AllTimes/variants?variantQuery=nextcladePangoLineage%3ABQ.1.2%2A%26%5B5-of%3A15960A%2C+17746T%2C+4414G%2C+29171A%2C+27513T%5D) | [View On Taxonium (Public Samples Only)](https://taxonium.org/?backend=https://api.cov2tree.org&srch=%5B%7B%22key%22%3A%22aa1%22%2C%22type%22%3A%22boolean%22%2C%22method%22%3A%22boolean%22%2C%22text%22%3A%22BQ.1.2%22%2C%22gene%22%3A%22S%22%2C%22position%22%3A484%2C%22new_residue%22%3A%22any%22%2C%22min_tips%22%3A0%2C%22subspecs%22%3A%5B%7B%22key%22%3A%22ab0%22%2C%22type%22%3A%22meta_pango_lineage_usher%22%2C%22method%22%3A%22text_exact%22%2C%22text%22%3A%22BQ.1.2%22%2C%22gene%22%3A%22S%22%2C%22position%22%3A484%2C%22new_residue%22%3A%22any%22%2C%22min_tips%22%3A0%7D%2C%7B%22key%22%3A%221ab%22%2C%22type%22%3A%22genotype%22%2C%22method%22%3A%22genotype%22%2C%22text%22%3A%22%22%2C%22gene%22%3A%22nt%22%2C%22position%22%3A%2215960%22%2C%22new_residue%22%3A%22A%22%2C%22min_tips%22%3A0%7D%2C%7B%22key%22%3A%222ab%22%2C%22type%22%3A%22genotype%22%2C%22method%22%3A%22genotype%22%2C%22text%22%3A%22%22%2C%22gene%22%3A%22nt%22%2C%22position%22%3A%2227513%22%2C%22new_residue%22%3A%22T%22%2C%22min_tips%22%3A0%7D%2C%7B%22key%22%3A%223ab%22%2C%22type%22%3A%22genotype%22%2C%22method%22%3A%22genotype%22%2C%22text%22%3A%22%22%2C%22gene%22%3A%22nt%22%2C%22position%22%3A%2229171%22%2C%22new_residue%22%3A%22A%22%2C%22min_tips%22%3A0%7D%2C%7B%22key%22%3A%224ab%22%2C%22type%22%3A%22genotype%22%2C%22method%22%3A%22genotype%22%2C%22text%22%3A%22%22%2C%22gene%22%3A%22nt%22%2C%22position%22%3A%2217746%22%2C%22new_residue%22%3A%22T%22%2C%22min_tips%22%3A0%7D%2C%7B%22key%22%3A%225ab%22%2C%22type%22%3A%22genotype%22%2C%22method%22%3A%22genotype%22%2C%22text%22%3A%22%22%2C%22gene%22%3A%22nt%22%2C%22position%22%3A%224414%22%2C%22new_residue%22%3A%22G%22%2C%22min_tips%22%3A0%7D%5D%2C%22boolean_method%22%3A%22and%22%7D%5D&enabled=%7B%22aa1%22%3A%22true%22%7D&zoomToSearch=0) |
| auto.BQ.1.13.2        | BQ.1.13   |                         68 | 2022-10-10       | 2022-12-01   |     68 | USA,Israel,Netherlands,England,Iceland,Australia,SouthKorea,Italy,France,Belgium,Canada                          | >S:F157L>                    | [View On Cov-Spectrum](https://cov-spectrum.org/explore/World/AllSamples/AllTimes/variants?variantQuery=nextcladePangoLineage%3ABQ.1.13%2A%26%5B3-of%3A22033A%2C+7318T%2C+26106C%5D)                    | [View On Taxonium (Public Samples Only)](https://taxonium.org/?backend=https://api.cov2tree.org&srch=%5B%7B%22key%22%3A%22aa1%22%2C%22type%22%3A%22boolean%22%2C%22method%22%3A%22boolean%22%2C%22text%22%3A%22BQ.1.13%22%2C%22gene%22%3A%22S%22%2C%22position%22%3A484%2C%22new_residue%22%3A%22any%22%2C%22min_tips%22%3A0%2C%22subspecs%22%3A%5B%7B%22key%22%3A%22ab0%22%2C%22type%22%3A%22meta_pango_lineage_usher%22%2C%22method%22%3A%22text_exact%22%2C%22text%22%3A%22BQ.1.13%22%2C%22gene%22%3A%22S%22%2C%22position%22%3A484%2C%22new_residue%22%3A%22any%22%2C%22min_tips%22%3A0%7D%2C%7B%22key%22%3A%221ab%22%2C%22type%22%3A%22genotype%22%2C%22method%22%3A%22genotype%22%2C%22text%22%3A%22%22%2C%22gene%22%3A%22nt%22%2C%22position%22%3A%227318%22%2C%22new_residue%22%3A%22T%22%2C%22min_tips%22%3A0%7D%2C%7B%22key%22%3A%222ab%22%2C%22type%22%3A%22genotype%22%2C%22method%22%3A%22genotype%22%2C%22text%22%3A%22%22%2C%22gene%22%3A%22nt%22%2C%22position%22%3A%2222033%22%2C%22new_residue%22%3A%22A%22%2C%22min_tips%22%3A0%7D%2C%7B%22key%22%3A%223ab%22%2C%22type%22%3A%22genotype%22%2C%22method%22%3A%22genotype%22%2C%22text%22%3A%22%22%2C%22gene%22%3A%22nt%22%2C%22position%22%3A%2226106%22%2C%22new_residue%22%3A%22C%22%2C%22min_tips%22%3A0%7D%5D%2C%22boolean_method%22%3A%22and%22%7D%5D&enabled=%7B%22aa1%22%3A%22true%22%7D&zoomToSearch=0)                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
| auto.BQ.1.23.2        | BQ.1.23   |                         43 | 2022-10-08       | 2022-12-01   |     43 | Indonesia,Singapore,USA,Spain,Bahrain,Australia,Turkey,SouthKorea,Portugal,Sweden,England,Iceland,Denmark,Greece | ORF1ab:T3488I                | [View On Cov-Spectrum](https://cov-spectrum.org/explore/World/AllSamples/AllTimes/variants?variantQuery=nextcladePangoLineage%3ABQ.1.23%2A%26%5B1-of%3A10728T%5D)                                       | [View On Taxonium (Public Samples Only)](https://taxonium.org/?backend=https://api.cov2tree.org&srch=%5B%7B%22key%22%3A%22aa1%22%2C%22type%22%3A%22boolean%22%2C%22method%22%3A%22boolean%22%2C%22text%22%3A%22BQ.1.23%22%2C%22gene%22%3A%22S%22%2C%22position%22%3A484%2C%22new_residue%22%3A%22any%22%2C%22min_tips%22%3A0%2C%22subspecs%22%3A%5B%7B%22key%22%3A%22ab0%22%2C%22type%22%3A%22meta_pango_lineage_usher%22%2C%22method%22%3A%22text_exact%22%2C%22text%22%3A%22BQ.1.23%22%2C%22gene%22%3A%22S%22%2C%22position%22%3A484%2C%22new_residue%22%3A%22any%22%2C%22min_tips%22%3A0%7D%2C%7B%22key%22%3A%221ab%22%2C%22type%22%3A%22genotype%22%2C%22method%22%3A%22genotype%22%2C%22text%22%3A%22%22%2C%22gene%22%3A%22nt%22%2C%22position%22%3A%2210728%22%2C%22new_residue%22%3A%22T%22%2C%22min_tips%22%3A0%7D%5D%2C%22boolean_method%22%3A%22and%22%7D%5D&enabled=%7B%22aa1%22%3A%22true%22%7D&zoomToSearch=0)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
| auto.BQ.1.1.4.3       | BQ.1.1.4  |                         79 | 2022-10-14       | 2022-12-01   |     79 | USA,Colombia,Guatemala,Denmark,Germany,Peru,CostaRica,Luxembourg,Canada,Chile,SouthKorea,Israel,Italy            | ORF7a:I100F                  | [View On Cov-Spectrum](https://cov-spectrum.org/explore/World/AllSamples/AllTimes/variants?variantQuery=nextcladePangoLineage%3ABQ.1.1.4%2A%26%5B1-of%3A27691T%5D)                                      | [View On Taxonium (Public Samples Only)](https://taxonium.org/?backend=https://api.cov2tree.org&srch=%5B%7B%22key%22%3A%22aa1%22%2C%22type%22%3A%22boolean%22%2C%22method%22%3A%22boolean%22%2C%22text%22%3A%22BQ.1.1.4%22%2C%22gene%22%3A%22S%22%2C%22position%22%3A484%2C%22new_residue%22%3A%22any%22%2C%22min_tips%22%3A0%2C%22subspecs%22%3A%5B%7B%22key%22%3A%22ab0%22%2C%22type%22%3A%22meta_pango_lineage_usher%22%2C%22method%22%3A%22text_exact%22%2C%22text%22%3A%22BQ.1.1.4%22%2C%22gene%22%3A%22S%22%2C%22position%22%3A484%2C%22new_residue%22%3A%22any%22%2C%22min_tips%22%3A0%7D%2C%7B%22key%22%3A%221ab%22%2C%22type%22%3A%22genotype%22%2C%22method%22%3A%22genotype%22%2C%22text%22%3A%22%22%2C%22gene%22%3A%22nt%22%2C%22position%22%3A%2227691%22%2C%22new_residue%22%3A%22T%22%2C%22min_tips%22%3A0%7D%5D%2C%22boolean_method%22%3A%22and%22%7D%5D&enabled=%7B%22aa1%22%3A%22true%22%7D&zoomToSearch=0)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
| auto.BQ.1.1.20.1      | BQ.1.1.20 |                         90 | 2022-10-24       | 2022-12-01   |     90 | Denmark,USA                                                                                                      | S:A1070V                     | [View On Cov-Spectrum](https://cov-spectrum.org/explore/World/AllSamples/AllTimes/variants?variantQuery=nextcladePangoLineage%3ABQ.1.1.20%2A%26%5B1-of%3A24771T%5D)                                     | [View On Taxonium (Public Samples Only)](https://taxonium.org/?backend=https://api.cov2tree.org&srch=%5B%7B%22key%22%3A%22aa1%22%2C%22type%22%3A%22boolean%22%2C%22method%22%3A%22boolean%22%2C%22text%22%3A%22BQ.1.1.20%22%2C%22gene%22%3A%22S%22%2C%22position%22%3A484%2C%22new_residue%22%3A%22any%22%2C%22min_tips%22%3A0%2C%22subspecs%22%3A%5B%7B%22key%22%3A%22ab0%22%2C%22type%22%3A%22meta_pango_lineage_usher%22%2C%22method%22%3A%22text_exact%22%2C%22text%22%3A%22BQ.1.1.20%22%2C%22gene%22%3A%22S%22%2C%22position%22%3A484%2C%22new_residue%22%3A%22any%22%2C%22min_tips%22%3A0%7D%2C%7B%22key%22%3A%221ab%22%2C%22type%22%3A%22genotype%22%2C%22method%22%3A%22genotype%22%2C%22text%22%3A%22%22%2C%22gene%22%3A%22nt%22%2C%22position%22%3A%2224771%22%2C%22new_residue%22%3A%22T%22%2C%22min_tips%22%3A0%7D%5D%2C%22boolean_method%22%3A%22and%22%7D%5D&enabled=%7B%22aa1%22%3A%22true%22%7D&zoomToSearch=0)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |